### PR TITLE
Add more robust response handling for org-gcal-fetch.

### DIFF
--- a/README.org
+++ b/README.org
@@ -4,7 +4,7 @@
   - Post/edit org element
 
 * Requirements
-
+ 
 - [[https://github.com/tkf/emacs-request][tkf/emacs-request]]
 - [[https://github.com/tekai/gntp.el][tekai/gntp.el]]
 

--- a/org-gcal.el
+++ b/org-gcal.el
@@ -7,7 +7,7 @@
 ;; Copyright (C) :2014 myuhe all rights reserved.
 ;; Created: :14-01-03
 ;; Package-Requires: ((request-deferred "0.2.0") (gntp "0.1") (emacs "24") (cl-lib "0.5") (org "8.2.4"))
-;; Keywords: convenience,
+;; Keywords: convenience, 
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published byn
@@ -32,7 +32,7 @@
 ;; (require 'org-gcal)
 ;;
 ;;; Changelog:
-;; 2014-01-03 Initial release.
+;; 2014-01-03 Initial release. 
 
 (require 'json)
 (require 'request-deferred)
@@ -79,7 +79,7 @@
   :type 'string)
 
 (defcustom org-gcal-client-secret nil
-  "Google calendar secret key for OAuth."
+  "Google calendar secret key for OAuth."  
   :group 'org-gcal
   :type 'string)
 
@@ -135,10 +135,10 @@
                          (a-token (if a-token
                                     a-token
                                   (org-gcal--get-access-token))))
-             (deferred:$
+             (deferred:$       
                (request-deferred
                 (format org-gcal-events-url (car x))
-                :type "GET"
+                :type "GET"        
                 :params `((access_token . ,a-token)
                           (key . ,org-gcal-client-secret)
                           (singleEvents . "True")
@@ -241,16 +241,16 @@ It returns the code provided by the service."
 
 (defun org-gcal-request-token ()
   "Request OAuth access at TOKEN-URL."
-  (request
+  (request 
    org-gcal-token-url
-   :type "POST"
+   :type "POST"        
    :data `(("client_id" . ,org-gcal-client-id)
            ("client_secret" . ,org-gcal-client-secret)
            ("code" . ,(org-gcal-request-authorization))
            ("redirect_uri" .  "urn:ietf:wg:oauth:2.0:oob")
            ("grant_type" . "authorization_code"))
    :parser 'org-gcal--json-read
-   :success (function*
+   :success (function* 
              (lambda (&key data &allow-other-keys)
                (when data
                  (setq org-gcal-token-plist data)
@@ -261,7 +261,7 @@ It returns the code provided by the service."
 
 (defun org-gcal-refresh-token (&optional fun start end smry loc desc id)
   "Refresh OAuth access at TOKEN-URL."
-  (interactive)
+  (interactive)  
   (lexical-let ((fun fun)
                 (start start)
                 (end end)
@@ -357,7 +357,7 @@ It returns the code provided by the service."
             (with-temp-buffer (insert-file-contents org-gcal-token-file)
                               (plist-get (read (buffer-string)) :access_token)))
         (message "\"%s\" is not exists" org-gcal-token-file)))))
-
+    
 (defun org-gcal--safe-substring (string from &optional to)
   "Calls the `substring' function safely.
 \nNo errors will be returned for out of range values of FROM and
@@ -378,7 +378,7 @@ TO.  Instead an empty string is returned."
   (let ((slst (org-gcal--parse-date s))
         (elst (org-gcal--parse-date e)))
     (and
-     (= (length s) 10)
+     (= (length s) 10) 
      (= (length e) 10)
      (= (- (time-to-seconds
             (encode-time 0 0 0
@@ -409,11 +409,11 @@ TO.  Instead an empty string is returned."
 (defun org-gcal--subsract-time ()
   (org-gcal--adjust-date 'time-subtract org-gcal-up-days))
 
-(defun org-gcal--format-iso2org (str &optional tz)
+(defun org-gcal--format-iso2org (str &optional tz) 
   (let ((plst (org-gcal--parse-date str)))
     (concat
      "<"
-     (format-time-string
+     (format-time-string 
       (if (< 11 (length str)) "%Y-%m-%d %a %H:%M" "%Y-%m-%d %a")
       (seconds-to-time
        (+ (if tz (car (current-time-zone)) 0)
@@ -430,7 +430,7 @@ TO.  Instead an empty string is returned."
 
 (defun org-gcal--format-org2iso (year mon day &optional hour min tz)
   (concat
-   (format-time-string
+   (format-time-string 
     (if (or hour min) "%Y-%m-%dT%H:%M" "%Y-%m-%d")
     (seconds-to-time
      (-
@@ -460,7 +460,7 @@ TO.  Instead an empty string is returned."
          (start (if stime stime sday))
          (end   (if etime etime eday)))
     (concat
-     "* " smry
+     "* " smry 
      (if (string= start end)
          (concat "\n  "(org-gcal--format-iso2org start))
        (if (and
@@ -485,7 +485,7 @@ TO.  Instead an empty string is returned."
                  "  :ID: " id "\n"
                  "  :END:\n\n")))
 
-(defun org-gcal--format-date (str format &optional tz)
+(defun org-gcal--format-date (str format &optional tz) 
   (let ((plst (org-gcal--parse-date str)))
     (concat
      (format-time-string format
@@ -553,7 +553,7 @@ TO.  Instead an empty string is returned."
    (org-gcal-token-plist t)
    ((and (file-exists-p org-gcal-token-file)
          (ignore-errors
-           (setq org-gcal-token-plist
+           (setq org-gcal-token-plist 
                  (with-temp-buffer
                    (insert-file-contents org-gcal-token-file)
                    (read (current-buffer))))))


### PR DESCRIPTION
This branch adds a `cond` expression to more explicitly handle various response cases. In particular my case was that I did not enable the Calendar API and so was getting a 403. This resulted in the endless loop referenced in myuhe#11.

To eliminate the endless loop, I cycle the token after receiving a 403. This will transparently allow the user to then go enable the Calendar API, then run `org-gcal-fetch` successfully.

In order to clarify the need to enable the Calendar API (one of those "obvious in hindsight" things...) I updated the installation steps to include doing so.
