### PR TITLE
Fix whitespace issues as well as issue #28

### DIFF
--- a/org-gcal.el
+++ b/org-gcal.el
@@ -671,6 +671,7 @@ beginning position."
             (with-current-buffer buf
                (let ((tmp (substring (buffer-string) (+ (string-match "\n\n" (buffer-string)) 2))))
                  (erase-buffer)
+		 (fundamental-mode)
                  (insert tmp)
                  (write-file file)))
             (kill-buffer buf)

--- a/org-gcal.el
+++ b/org-gcal.el
@@ -562,8 +562,8 @@ TO.  Instead an empty string is returned."
                   (if (< 11 (length end))
                       end
                     (org-gcal--iso-previous-day end)))))) "\n"
-                 desc ;; (when desc "\n")
-                 "\n")))
+		    desc
+		    (when desc (if (string-match-p "\n$" desc) "" "\n")))))
 
 (defun org-gcal--format-date (str format &optional tz)
   (let ((plst (org-gcal--parse-date str)))

--- a/org-gcal.el
+++ b/org-gcal.el
@@ -555,13 +555,14 @@ TO.  Instead an empty string is returned."
                    (org-gcal--format-date start "%Y-%m-%d %a %H:%M")
                    "-"
                    (org-gcal--format-date end "%H:%M")
-                   ">\n")
+                   ">")
          (concat "\n  " (org-gcal--format-iso2org start)
                  "--"
                  (org-gcal--format-iso2org
                   (if (< 11 (length end))
                       end
                     (org-gcal--iso-previous-day end)))))) "\n"
+		    (when desc "\n")
 		    desc
 		    (when desc (if (string-match-p "\n$" desc) "" "\n")))))
 

--- a/org-gcal.el
+++ b/org-gcal.el
@@ -291,7 +291,7 @@
                       (replace-regexp-in-string
                        " *:PROPERTIES:\n  \\(.*\\(?:\n.*\\)*?\\) :END:\n\n" ""
                        (replace-regexp-in-string
-                        "<[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].*?>\n\n" ""
+                        " *<[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].*?>\n\n" ""
                         (buffer-substring-no-properties
                          (plist-get (cadr elem) :contents-begin)
                          (plist-get (cadr elem) :contents-end)))) "")))


### PR DESCRIPTION
Hello,

I would like to propose some minor fixes, regarding whitespaces issues in `org-gcal.el`.

This pull request also fixes #28 (following [this comment](https://github.com/myuhe/org-gcal.el/issues/28#issuecomment-103417882)).
However, I did not include in this pull request the other change suggested in [that comment](https://github.com/myuhe/org-gcal.el/issues/28#issuecomment-104017101) (cf. erikmd/org-gcal.el@41c8529), given that the expression `(expand-file-name (concat  (file-name-directory (locate-library "org-gcal")) org-gcal-logo)` could just as well point to some non-writable directory, such as `/usr/share/sth`...

Best regards.