### PR TITLE
Specify the query parameter orderBy to fix the order of Gcal events at each fetch

### DIFF
--- a/org-gcal.el
+++ b/org-gcal.el
@@ -140,6 +140,7 @@
                 :params `((access_token . ,a-token)
                           (key . ,org-gcal-client-secret)
                           (singleEvents . "True")
+			  (orderBy . "startTime")
                           (timeMin . ,(org-gcal--subsract-time))
                           (timeMax . ,(org-gcal--add-time))
                           ("grant_type" . "authorization_code"))


### PR DESCRIPTION
Hello,

I observed the following behavior: after each sync, the order of events that are already known by Gcal is turned upside down, roughly depending on the last modification date stored by Gcal for each event.

As it is somewhat distracting for the user, I propose this small patch which ensures that the order of events fetched from Gcal is stable. (Namely, events are now ordered by increasing start date.)

Best regards.