### PR TITLE
Fix two regex issues in (org-gcal-post-at-point)

### DIFF
--- a/org-gcal.el
+++ b/org-gcal.el
@@ -289,7 +289,7 @@
                    t)))
            (desc  (if (plist-get (cadr elem) :contents-begin)
                       (replace-regexp-in-string
-                       " *<[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].*?>\n\n" ""
+                       "\\`\\(?: *<[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].*?>$\\)\n?\n?" ""
                        (replace-regexp-in-string
                         " *:PROPERTIES:\n  \\(.*\\(?:\n.*\\)*?\\) :END:\n\n" ""
                         (buffer-substring-no-properties

--- a/org-gcal.el
+++ b/org-gcal.el
@@ -289,9 +289,9 @@
                    t)))
            (desc  (if (plist-get (cadr elem) :contents-begin)
                       (replace-regexp-in-string
-                       " *:PROPERTIES:\n  \\(.*\\(?:\n.*\\)*?\\) :END:\n\n" ""
+                       " *<[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].*?>\n\n" ""
                        (replace-regexp-in-string
-                        " *<[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].*?>\n\n" ""
+                        " *:PROPERTIES:\n  \\(.*\\(?:\n.*\\)*?\\) :END:\n\n" ""
                         (buffer-substring-no-properties
                          (plist-get (cadr elem) :contents-begin)
                          (plist-get (cadr elem) :contents-end)))) "")))


### PR DESCRIPTION
Hello,

This patch fixes two issues related to the timestamp parsing in `(org-gcal-post-at-point)`.

Best regards.