### PR TITLE
Fix time-zone issue

### DIFF
--- a/org-gcal.el
+++ b/org-gcal.el
@@ -503,7 +503,7 @@ TO.  Instead an empty string is returned."
                     day mon year))
       (if tz
           (car (current-time-zone)) 0))))
-   (when (or hour min) ":00z")))
+   (when (or hour min) ":00Z")))
 
 (defun org-gcal--iso-next-day (str &optional previous-p)
   (let ((format (if (< 11 (length str))


### PR DESCRIPTION
Hello,

With the current version of `org-gcal.el`, if we post an event that will occur after a Daylight Saving Time change, the code does not take into account the appropriate time zone.

This patch fixes that issue.

Best regards.