### PR TITLE
fix mangled calendar entries

### DIFF
--- a/org-gcal.el
+++ b/org-gcal.el
@@ -540,7 +540,7 @@ TO.  Instead an empty string is returned."
          (start (if stime stime sday))
          (end   (if etime etime eday)))
     (concat
-     "* " smry "\n"
+     "\n\n* " smry "\n"
      "  :PROPERTIES:\n"
      (when loc "  :LOCATION: ") loc (when loc "\n")
      "  :LINK: ""[[" link "][Go to gcal web page]]\n"


### PR DESCRIPTION
Some Google Calendar entries did not have a newline at the end of a description. As a consequence following calendar entries start on the same line as the last description line which then will mess up org agenda view.