### PR TITLE
Decode download content explicitly

### DIFF
--- a/org-gcal.el
+++ b/org-gcal.el
@@ -424,7 +424,9 @@ It returns the code provided by the service."
     (re-search-forward "^{" nil t)
     (delete-region (point-min) (1- (point)))
     (goto-char (point-min))
-    (json-read)))
+    (json-read-from-string
+     (decode-coding-string
+      (buffer-substring-no-properties (point-min) (point-max)) 'utf-8))))
 
 (defun org-gcal--get-refresh-token ()
   (if org-gcal-token-plist


### PR DESCRIPTION
Older request.el decodes in Emacs default encoding. While newer request.el
does not decode and callback function takes byte data(not string).

This is related to #48 and https://github.com/abingham/emacs-request/pull/5
CC: @elandx, @lurdan

Here are screenshots.

#### Original

![before](https://cloud.githubusercontent.com/assets/554281/13565489/bc711e86-e493-11e5-9ae0-88efe3373ae9.png)

#### Fixed version

![after](https://cloud.githubusercontent.com/assets/554281/13565494/c4cfc442-e493-11e5-8d5e-372858bb3b56.png)
