### PR TITLE
Fix bug checking if last character is a newline

### DIFF
--- a/org-gcal.el
+++ b/org-gcal.el
@@ -592,7 +592,7 @@ TO.  Instead an empty string is returned."
                     (org-gcal--iso-previous-day end)))))) "\n"
 		    (when desc "\n")
 		    desc
-		    (when desc (if (string-match-p "\n$" desc) "" "\n")))))
+		    (when desc (if (string= "\n" (org-gcal--safe-substring desc -1)) "" "\n")))))
 
 (defun org-gcal--format-date (str format &optional tz)
   (let* ((plst (org-gcal--parse-date str))


### PR DESCRIPTION
Hi there!

Awesome package, thanks a lot!

There seems to be a minor bug when creating the org-mode files when events have descriptions that have a double newline in them.
The line containing `(string-match-p "\n$" desc)` is supposed to check if the last character is a newline, so it can add one if there isn't. However, this fails for weird cases where the description contains a double newline but doesn't end with a newline, such as `(string-match-p "\n$" "Blah blah blah\n\n blah")`.
This creates problems where headings aren't properly created.

I made a quick change that fixes this, explicitly getting the last character of the description string and checking it against "\n".

Let me know if you have any questions about this.

Thanks!