### PR TITLE
Allow the insertion of headers to org-gcal files

### DIFF
--- a/org-gcal.el
+++ b/org-gcal.el
@@ -110,6 +110,8 @@
 (defvar org-gcal-icon-list '("org.png" "emacs.png")
   "icon file name list.")
 
+(defvar org-gcal-header-alist ())
+
 (defconst org-gcal-auth-url "https://accounts.google.com/o/oauth2/auth"
   "Google OAuth2 server URL.")
 
@@ -222,6 +224,8 @@
                            (org-gcal-sync nil t t)))
                          (erase-buffer)
                          (let ((items (org-gcal--filter (plist-get (request-response-data response) :items ))))
+			   (if (assoc (car x) org-gcal-header-alist)
+			       (insert (cdr (assoc (car x) org-gcal-header-alist))))
                            (insert
                             (mapconcat 'identity
                                        (mapcar (lambda (lst)


### PR DESCRIPTION
I often need to set headers in org-mode files to control categories, archive locations, and other local variables.  This patch allows for the insertion of arbitary headers.

It creates a single alist variable (org-gcal-header-alist) and if it exists for a given file it inserts it before writing the calendar items.
## 

created variable org-gcal-header-alist

example:
(setq org-gcal-header-alist '(("me@gmail.com" . "#+CATEGORY: personal\n")))
