### PR TITLE
[WIP] Add multiple accounts support

### DIFF
--- a/org-gcal.el
+++ b/org-gcal.el
@@ -104,8 +104,8 @@
   :group 'org-gcal
   :type 'list)
 
-(defvar org-gcal-token-plist nil
-  "token plist.")
+(defvar org-gcal-tokens-plist '()
+  "token plists.")
 
 (defvar org-gcal-icon-list '("org.png" "emacs.png")
   "icon file name list.")
@@ -125,7 +125,6 @@
 
 (defun org-gcal-sync (&optional a-token skip-export silent)
   (interactive)
-  (org-gcal--ensure-token)
   (when org-gcal-auto-archive
     (dolist (i org-gcal-file-alist)
       (with-current-buffer
@@ -133,13 +132,14 @@
         (org-gcal--archive-old-event))))
   (cl-loop for x in org-gcal-file-alist
            do
-           (let ((x x)
+           (let* ((x x)
+		 (calendar-url (car x))
                  (a-token (if a-token
                               a-token
-                            (org-gcal--get-access-token)))
-
+                            (org-gcal--get-access-token calendar-url)))
                  (skip-export skip-export)
                  (silent silent))
+	     (org-gcal--ensure-token calendar-url)
              (deferred:$
                (request-deferred
                 (format org-gcal-events-url (car x))
@@ -204,7 +204,7 @@
                        (with-current-buffer (find-file-noselect (cdr x))
                          (unless skip-export
                            (save-excursion
-                             (cl-loop with buf = (find-file-noselect org-gcal-token-file)
+                             (cl-loop with buf = (find-file-noselect (concat org-gcal-token-file calendar-url))
                                       for local-event in (org-gcal--parse-id (cdr x))
                                       for pos in (org-gcal--headline-list (cdr x))
                                       when (or
@@ -215,7 +215,7 @@
                                                                                         (plist-get (read (buffer-string)) (intern (concat ":" (car x))))))))))
                                       do
                                       (goto-char pos)
-                                      (org-gcal-post-at-point t)
+                                      (org-gcal-post-at-point t calendar-url)
                                       finally
                                       (kill-buffer buf))
                            (sit-for 2)
@@ -227,9 +227,9 @@
                                        (mapcar (lambda (lst)
                                                  (org-gcal--cons-list lst))
                                                items) ""))
-                           (let ((plst (with-temp-buffer (insert-file-contents org-gcal-token-file)
+                           (let ((plst (with-temp-buffer (insert-file-contents (concat org-gcal-token-file calendar-url))
                                                          (read (buffer-string)))))
-                             (with-temp-file org-gcal-token-file (pp (plist-put plst (intern (concat ":" (car x))) (mapcar (lambda (lst)
+                             (with-temp-file (concat org-gcal-token-file calendar-url) (pp (plist-put plst (intern (concat ":" (car x))) (mapcar (lambda (lst)
                                                                                                                              (cons (plist-get lst :id) (org-gcal--cons-list lst)))
                                                                                                                            items)) (current-buffer)))))
                          (org-set-startup-visibility)
@@ -279,9 +279,16 @@
                                 (car (org-element-map (org-element-at-point) 'headline
                                   (lambda (hl) (org-element-property :end hl)))))))))))
 
-(defun org-gcal-post-at-point (&optional skip-import)
+(defun org-gcal-post-at-point (&optional skip-import calendar-url)
   (interactive)
-  (org-gcal--ensure-token)
+  (message (buffer-file-name))
+  (let ((calendar-url (if calendar-url
+						  calendar-url
+						(car (rassoc (buffer-file-name) org-gcal-file-alist))
+						)))
+	(message (concat "post-at-point " calendar-url))
+	)
+  (org-gcal--ensure-token calendar-url)
   (save-excursion
     (end-of-line)
     (org-back-to-heading)
@@ -320,7 +327,7 @@
                          (plist-get (cadr elem) :contents-end)))) "")))
       (org-gcal--post-event start end smry loc desc id nil skip-import))))
 
-(defun org-gcal-request-authorization ()
+(defun org-gcal-request-authorization (calendar-url)
   "Request OAuth authorization at AUTH-URL by launching `browse-url'.
 CLIENT-ID is the client id provided by the provider.
 It returns the code provided by the service."
@@ -329,24 +336,24 @@ It returns the code provided by the service."
                       "&response_type=code"
                       "&redirect_uri=" (url-hexify-string "urn:ietf:wg:oauth:2.0:oob")
                       "&scope=" (url-hexify-string org-gcal-resource-url)))
-  (read-string "Enter the code your browser displayed: "))
+  (read-string (concat "(" calendar-url  ") Enter the code your browser displayed: ")))
 
-(defun org-gcal-request-token ()
+(defun org-gcal-request-token (calendar-url)
   "Request OAuth access at TOKEN-URL."
   (request
    org-gcal-token-url
    :type "POST"
    :data `(("client_id" . ,org-gcal-client-id)
            ("client_secret" . ,org-gcal-client-secret)
-           ("code" . ,(org-gcal-request-authorization))
+           ("code" . ,(org-gcal-request-authorization calendar-url))
            ("redirect_uri" .  "urn:ietf:wg:oauth:2.0:oob")
            ("grant_type" . "authorization_code"))
    :parser 'org-gcal--json-read
    :success (cl-function
              (lambda (&key data &allow-other-keys)
                (when data
-                 (setq org-gcal-token-plist data)
-                 (org-gcal--save-sexp data org-gcal-token-file))))
+                 (setq org-gcal-tokens-plist (plist-put org-gcal-tokens-plist calendar-url data))
+                 (org-gcal--save-sexp data (concat org-gcal-token-file calendar-url)))))
    :error
    (cl-function (lambda (&key error-thrown &allow-other-keys)
                 (message "Got error: %S" error-thrown)))))
@@ -354,13 +361,18 @@ It returns the code provided by the service."
 (defun org-gcal-refresh-token (&optional fun skip-export start end smry loc desc id)
   "Refresh OAuth access at TOKEN-URL."
   (interactive)
+  (cl-loop for x in org-gcal-file-alist
+           do
+           (let* ((x x)
+		 (calendar-url (car x))
+		 (plist (plist-get org-gcal-tokens-plist calendar-url )))
     (deferred:$
       (request-deferred
        org-gcal-token-url
        :type "POST"
        :data `(("client_id" . ,org-gcal-client-id)
                ("client_secret" . ,org-gcal-client-secret)
-               ("refresh_token" . ,(org-gcal--get-refresh-token))
+               ("refresh_token" . ,(org-gcal--get-refresh-token calendar-url))
                ("grant_type" . "refresh_token"))
        :parser 'org-gcal--json-read
        :error
@@ -369,17 +381,17 @@ It returns the code provided by the service."
       (deferred:nextc it
         (lambda (response)
           (let ((temp (request-response-data response)))
-            (plist-put org-gcal-token-plist
+            (plist-put plist
                        :access_token
                        (plist-get temp :access_token))
-            (org-gcal--save-sexp org-gcal-token-plist org-gcal-token-file)
-            org-gcal-token-plist)))
+            (org-gcal--save-sexp plist (concat org-gcal-token-file calendar-url))
+	    (setq org-gcal-tokens-plist (plist-put org-gcal-tokens-plist calendar-url plist)))))
       (deferred:nextc it
         (lambda (token)
           (cond ((eq fun 'org-gcal-sync)
                  (org-gcal-sync (plist-get token :access_token) skip-export))
                 ((eq fun 'org-gcal--post-event)
-                 (org-gcal--post-event start end smry loc desc id (plist-get token :access_token))))))))
+                 (org-gcal--post-event start end smry loc desc calendar-url id (plist-get token :access_token))))))))))
 
 ;; Internal
 (defun org-gcal--archive-old-event ()
@@ -428,29 +440,29 @@ It returns the code provided by the service."
      (decode-coding-string
       (buffer-substring-no-properties (point-min) (point-max)) 'utf-8))))
 
-(defun org-gcal--get-refresh-token ()
-  (if org-gcal-token-plist
-      (plist-get org-gcal-token-plist :refresh_token)
+(defun org-gcal--get-refresh-token (calendar-url)
+  (if (plist-get org-gcal-tokens-plist calendar-url)
+      (plist-get (plist-get org-gcal-tokens-plist calendar-url) :refresh_token)
     (progn
-      (if (file-exists-p org-gcal-token-file)
+      (if (file-exists-p (concat org-gcal-token-file calendar-url))
           (progn
-            (with-temp-buffer (insert-file-contents org-gcal-token-file)
+            (with-temp-buffer (insert-file-contents (concat org-gcal-token-file calendar-url))
                               (plist-get (plist-get (read (buffer-string)) :token) :refresh_token)))
         (org-gcal--notify 
-         (concat org-gcal-token-file " is not exists" )
-         (concat "Make" org-gcal-token-file))))))
+         (concat (concat org-gcal-token-file calendar-url) " is not exists" )
+         (concat "Make" (concat org-gcal-token-file calendar-url)))))))
 
-(defun org-gcal--get-access-token ()
-  (if org-gcal-token-plist
-      (plist-get org-gcal-token-plist :access_token)
+(defun org-gcal--get-access-token (calendar-url)
+  (if (plist-get org-gcal-tokens-plist calendar-url)
+      (plist-get (plist-get org-gcal-tokens-plist calendar-url) :access_token)
     (progn
-      (if (file-exists-p org-gcal-token-file)
+      (if (file-exists-p (concat org-gcal-token-file calendar-url))
           (progn
-            (with-temp-buffer (insert-file-contents org-gcal-token-file)
+            (with-temp-buffer (insert-file-contents (concat org-gcal-token-file calendar-url))
                               (plist-get (plist-get (read (buffer-string)) :token) :access_token)))
         (org-gcal--notify 
-         (concat org-gcal-token-file " is not exists" )
-         (concat "Make " org-gcal-token-file))))))
+         (concat (concat org-gcal-token-file calendar-url) " is not exists" )
+         (concat "Make " (concat org-gcal-token-file calendar-url)))))))
 
 (defun org-gcal--safe-substring (string from &optional to)
   "Calls the `substring' function safely.
@@ -609,14 +621,14 @@ TO.  Instead an empty string is returned."
 (defun org-gcal--param-date-alt (str)
   (if (< 11 (length str)) "date" "dateTime"))
 
-(defun org-gcal--post-event (start end smry loc desc &optional id a-token skip-import skip-export)
+(defun org-gcal--post-event (start end smry loc desc calendar-url &optional id a-token skip-import skip-export)
   (let ((stime (org-gcal--param-date start))
         (etime (org-gcal--param-date end))
         (stime-alt (org-gcal--param-date-alt start))
         (etime-alt (org-gcal--param-date-alt end))
         (a-token (if a-token
                      a-token
-                   (org-gcal--get-access-token))))
+                   (org-gcal--get-access-token calendar-url))))
     (request
      (concat
       (format org-gcal-events-url (car (car org-gcal-file-alist)))
@@ -666,16 +678,16 @@ TO.  Instead an empty string is returned."
 
 (add-hook 'org-capture-before-finalize-hook 'org-gcal--capture-post)
 
-(defun org-gcal--ensure-token ()
+(defun org-gcal--ensure-token (calendar-url)
   (cond
-   (org-gcal-token-plist t)
-   ((and (file-exists-p org-gcal-token-file)
+   ((plist-get org-gcal-tokens-plist calendar-url) t)
+   ((and (file-exists-p (concat org-gcal-token-file calendar-url))
          (ignore-errors
-           (setq org-gcal-token-plist
+           (setq org-gcal-tokens-plist (plist-put org-gcal-tokens-plist calendar-url
                  (with-temp-buffer
-                   (insert-file-contents org-gcal-token-file)
-                   (plist-get (read (current-buffer)) :token))))) t)
-   (t (org-gcal-request-token))))
+                   (insert-file-contents (concat org-gcal-token-file calendar-url))
+                   (plist-get (read (current-buffer)) :token)))))) t)
+   (t (org-gcal-request-token calendar-url))))
 
 (defun org-gcal--timestamp-successor ()
   "Search for the next timestamp object.


### PR DESCRIPTION
A solution to issue #71 where calendars on different google accounts can't be synced at the same time because they have different access tokens.

`org-gcal-token-plist` has been renamed to `org-gcal-tokens-plist` and contains each calendars plist. The calendar's url is used as the key.
Each calendars plist is also saved in separate files i.e.`(concat org-gcal-token-file calendar-url)` 
All the `(plist-get org-gcal-tokens-plist calendar-url)` calls can be cleaned up.