### PR TITLE
Show "busy" for private events

### DIFF
--- a/org-gcal.el
+++ b/org-gcal.el
@@ -548,7 +548,8 @@ TO.  Instead an empty string is returned."
   (org-gcal--iso-next-day str t))
 
 (defun org-gcal--cons-list (plst)
-  (let* ((smry  (plist-get plst :summary))
+  (let* ((smry  (or (plist-get plst :summary)
+                    "busy"))
          (desc  (plist-get plst :description))
          (loc   (plist-get plst :location))
          (link  (plist-get plst :htmlLink))


### PR DESCRIPTION
Previously, private events were not emitted correctly which would cause the event prior to the private event to have multiple times.